### PR TITLE
fix(user,address): 배송지 연관관계 매핑 및 기본 배송지 조회 반영

### DIFF
--- a/src/main/java/com/groom/e_commerce/user/application/service/AddressServiceV1.java
+++ b/src/main/java/com/groom/e_commerce/user/application/service/AddressServiceV1.java
@@ -42,6 +42,8 @@ public class AddressServiceV1 {
 
 		AddressEntity address = AddressEntity.builder()
 			.user(user)
+                .recipient(request.getRecipient()) // 추가
+                .recipientPhone(request.getRecipientPhone()) // 추가
 			.zipCode(request.getZipCode())
 			.address(request.getAddress())
 			.detailAddress(request.getDetailAddress())
@@ -89,6 +91,7 @@ public class AddressServiceV1 {
 
 		addressRepository.clearDefaultAddress(userId);
 		address.setDefault(true);
+
 		log.info("Default address set: {}", addressId);
 	}
 

--- a/src/main/java/com/groom/e_commerce/user/application/service/UserServiceV1.java
+++ b/src/main/java/com/groom/e_commerce/user/application/service/UserServiceV1.java
@@ -5,6 +5,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+import com.groom.e_commerce.user.domain.entity.AddressEntity;
+import com.groom.e_commerce.user.domain.repository.AddressRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,11 +33,20 @@ import lombok.extern.slf4j.Slf4j;
 public class UserServiceV1 {
 
 	private final UserRepository userRepository;
+    private final AddressRepository addressRepository;
 	private final PasswordEncoder passwordEncoder;
 
 	public ResUserDtoV1 getMe() {
 		UUID userId = SecurityUtil.getCurrentUserId();
-		return ResUserDtoV1.from(findUserById(userId));
+
+        // -- 기본 배송지 조회 --
+        UserEntity user = findUserById(userId);
+
+        AddressEntity defaultAddress = addressRepository
+                .findByUserUserIdAndIsDefaultTrue(userId)
+                .orElse(null);
+
+        return ResUserDtoV1.from(user, defaultAddress);
 	}
 
 	@Transactional

--- a/src/main/java/com/groom/e_commerce/user/domain/entity/AddressEntity.java
+++ b/src/main/java/com/groom/e_commerce/user/domain/entity/AddressEntity.java
@@ -34,6 +34,7 @@ public class AddressEntity {
 	@Column(name = "address_id", columnDefinition = "uuid")
 	private UUID addressId;
 
+    // User Table Mapping
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private UserEntity user;

--- a/src/main/java/com/groom/e_commerce/user/domain/entity/OwnerStatus.java
+++ b/src/main/java/com/groom/e_commerce/user/domain/entity/OwnerStatus.java
@@ -1,0 +1,7 @@
+package com.groom.e_commerce.user.domain.entity;
+
+public enum OwnerStatus {
+    PENDING,    // 승인 대기
+    APPROVED,   // 승인됨
+    REJECTED    // 거절됨
+}

--- a/src/main/java/com/groom/e_commerce/user/domain/repository/AddressRepository.java
+++ b/src/main/java/com/groom/e_commerce/user/domain/repository/AddressRepository.java
@@ -19,7 +19,9 @@ public interface AddressRepository extends JpaRepository<AddressEntity, UUID> {
 
 	Optional<AddressEntity> findByAddressIdAndUserUserId(UUID addressId, UUID userId);
 
-	@Modifying
+    Optional<AddressEntity> findByUserUserIdAndIsDefaultTrue(UUID userId);
+
+    @Modifying
 	@Query("UPDATE AddressEntity a SET a.isDefault = false WHERE a.user.userId = :userId AND a.isDefault = true")
 	void clearDefaultAddress(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/groom/e_commerce/user/presentation/controller/AddressControllerV1.java
+++ b/src/main/java/com/groom/e_commerce/user/presentation/controller/AddressControllerV1.java
@@ -35,7 +35,7 @@ public class AddressControllerV1 {
 	@Operation(summary = "배송지 목록 조회")
 	@GetMapping
 	public ResponseEntity<List<ResAddressDtoV1>> getAddresses(@AuthenticationPrincipal CustomUserDetails user) {
-		return ResponseEntity.ok(addressService.getAddresses(user.getUserId()));
+        return ResponseEntity.ok(addressService.getAddresses(user.getUserId()));
 	}
 
 	@Operation(summary = "배송지 등록")

--- a/src/main/java/com/groom/e_commerce/user/presentation/dto/response/ResUserDtoV1.java
+++ b/src/main/java/com/groom/e_commerce/user/presentation/dto/response/ResUserDtoV1.java
@@ -3,6 +3,7 @@ package com.groom.e_commerce.user.presentation.dto.response;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.groom.e_commerce.user.domain.entity.AddressEntity;
 import com.groom.e_commerce.user.domain.entity.UserEntity;
 import com.groom.e_commerce.user.domain.entity.UserRole;
 import com.groom.e_commerce.user.domain.entity.UserStatus;
@@ -20,10 +21,27 @@ public class ResUserDtoV1 {
 	private String phoneNumber;
 	private UserRole role;
 	private UserStatus status;
-	private LocalDateTime createdAt;
+	// 기본 배송지 추가
+    private ResAddressDtoV1 defaultAddress;
+    // --------------
+    private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 
-	public static ResUserDtoV1 from(UserEntity user) {
+
+    public static ResUserDtoV1 from(UserEntity user) {
+        return ResUserDtoV1.builder()
+                .id(user.getUserId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .phoneNumber(user.getPhoneNumber())
+                .role(user.getRole())
+                .status(user.getStatus())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+
+	public static ResUserDtoV1 from(UserEntity user, AddressEntity defaultAddress) {
 		return ResUserDtoV1.builder()
 			.id(user.getUserId())
 			.email(user.getEmail())
@@ -31,6 +49,7 @@ public class ResUserDtoV1 {
 			.phoneNumber(user.getPhoneNumber())
 			.role(user.getRole())
 			.status(user.getStatus())
+            .defaultAddress(defaultAddress != null ? ResAddressDtoV1.from(defaultAddress) : null)
 			.createdAt(user.getCreatedAt())
 			.updatedAt(user.getUpdatedAt())
 			.build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

ref #10 

## #️⃣ 작업 내용

- UserEntity ↔ AddressEntity 연관관계 매핑 적용
   - @OneToMany(mappedBy = "user") / @ManyToOne 기반으로 사용자-배송지 관계 정리
- 기본 배송지 조회 로직을 /users/me 응답에 반영
   - findByUserUserIdAndIsDefaultTrue 로 기본 배송지 조회
   - /users/me 응답 DTO에 기본 배송지 정보를 포함하도록 수정
- 기본 배송지 변경 로직 정리
   - 기본 배송지 변경 시 기존 기본값을 해제하는 clearDefaultAddress 로직 적용
   - “한 사용자당 기본 배송지는 1개”가 유지되도록 처리

## #️⃣ 테스트 결과

- 로컬에서 기본 배송지 등록/변경 시나리오 테스트 완료
- 기본 배송지 변경 시 기존 기본값이 정상 해제되는지 확인
- /user/me 조회 시 기본 배송지 정보가 정상 포함되는지 확인

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?